### PR TITLE
Add strict types across routes

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -2,11 +2,12 @@
 
 import { useEffect, useState } from 'react'
 import { supabase } from '@/lib/supabase'
+import type { NewsFormData, NewsItem } from '@/lib/types'
 
-export default function AdminPage() {
-  const [newsItems, setNewsItems] = useState<any[]>([])
-  const [loading, setLoading] = useState(true)
-  const [form, setForm] = useState({
+export default function AdminPage(): JSX.Element {
+  const [newsItems, setNewsItems] = useState<NewsItem[]>([])
+  const [loading, setLoading] = useState<boolean>(true)
+  const [form, setForm] = useState<NewsFormData>({
     headline: '',
     ticker: '',
     sentiment: '',
@@ -17,7 +18,7 @@ export default function AdminPage() {
     fetchNews()
   }, [])
 
-  async function fetchNews() {
+  async function fetchNews(): Promise<void> {
     setLoading(true)
     const { data, error } = await supabase
       .from('news_items')
@@ -33,7 +34,9 @@ export default function AdminPage() {
     setLoading(false)
   }
 
-  async function handleSubmit(e: React.FormEvent) {
+  async function handleSubmit(
+    e: React.FormEvent<HTMLFormElement>
+  ): Promise<void> {
     e.preventDefault()
     const { error } = await supabase.from('news_items').insert([
       {
@@ -52,7 +55,7 @@ export default function AdminPage() {
     }
   }
 
-  async function handleDelete(id: string) {
+  async function handleDelete(id: string): Promise<void> {
     const { error } = await supabase.from('news_items').delete().eq('id', id)
     if (error) {
       console.error('Delete error:', error)

--- a/src/app/api/news/route.ts
+++ b/src/app/api/news/route.ts
@@ -8,7 +8,7 @@ const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;
 
 const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
 
-export async function GET() {
+export async function GET(): Promise<NextResponse> {
   try {
     if (!NEWS_API_KEY) {
       throw new Error('Missing NEWS_API_KEY in environment variables');

--- a/src/app/api/news/stored/route.ts
+++ b/src/app/api/news/stored/route.ts
@@ -7,7 +7,7 @@ const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;
 
 const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
 
-export async function GET() {
+export async function GET(): Promise<NextResponse> {
   try {
     const { data, error } = await supabase
       .from('news_items')

--- a/src/app/api/stocks/route.ts
+++ b/src/app/api/stocks/route.ts
@@ -12,7 +12,7 @@ const companyInfo: Record<string, { name: string; logo: string }> = {
   TSLA: { name: 'Tesla Inc.', logo: 'https://logo.clearbit.com/tesla.com' }
 };
 
-export async function GET() {
+export async function GET(): Promise<NextResponse> {
   try {
     const quotes = await Promise.all(
       symbols.map(async (symbol) => {

--- a/src/app/api/test/route.ts
+++ b/src/app/api/test/route.ts
@@ -1,7 +1,7 @@
 // src/app/api/test/route.ts
 import { NextResponse } from 'next/server';
 
-export async function GET() {
+export async function GET(): Promise<NextResponse> {
   const apiKey = process.env.FINNHUB_API_KEY;
   if (!apiKey) {
     return NextResponse.json({ error: 'Missing FINNHUB_API_KEY' }, { status: 500 });

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,7 +8,7 @@ export const metadata: Metadata = {
   description: 'Live stock headlines and AI signals',
 };
 
-export default function RootLayout({ children }: { children: ReactNode }) {
+export default function RootLayout({ children }: { children: ReactNode }): JSX.Element {
   return (
     <html lang="en">
       <body>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -4,16 +4,18 @@ import { useState } from 'react';
 import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
 import { useRouter } from 'next/navigation';
 
-export default function LoginPage() {
+export default function LoginPage(): JSX.Element {
   const supabase = createClientComponentClient();
   const router = useRouter();
 
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [message, setMessage] = useState('');
-  const [showPassword, setShowPassword] = useState(false);
+  const [email, setEmail] = useState<string>('');
+  const [password, setPassword] = useState<string>('');
+  const [message, setMessage] = useState<string>('');
+  const [showPassword, setShowPassword] = useState<boolean>(false);
 
-  const handleLogin = async (e: React.FormEvent) => {
+  const handleLogin = async (
+    e: React.FormEvent<HTMLFormElement>
+  ): Promise<void> => {
     e.preventDefault();
 
     const { data: loginData, error: loginError } = await supabase.auth.signInWithPassword({

--- a/src/app/news/page.tsx
+++ b/src/app/news/page.tsx
@@ -15,13 +15,13 @@ type NewsItem = {
   signal?: 'buy' | 'sell' | 'hold';
 };
 
-export default function NewsPage() {
+export default function NewsPage(): JSX.Element {
   const [news, setNews] = useState<NewsItem[]>([]);
-  const [search, setSearch] = useState('');
-  const [sentimentFilter, setSentimentFilter] = useState('');
+  const [search, setSearch] = useState<string>('');
+  const [sentimentFilter, setSentimentFilter] = useState<string>('');
 
   useEffect(() => {
-    const fetchNews = async () => {
+    const fetchNews = async (): Promise<void> => {
       try {
         const res = await fetch('/api/news/stored');
         const data = await res.json();

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,29 +3,19 @@
 import { useEffect, useState } from 'react';
 import { createPagesBrowserClient } from '@supabase/auth-helpers-nextjs';
 import { useRouter } from 'next/navigation';
-import React from 'react';
+import type { NewsItem } from '@/lib/types';
 
-interface NewsItem {
-  id: string;
-  published_at: string;
-  headline: string;
-  ticker: string;
-  sentiment: string;
-  signal: string;
-}
-
-export default function Home() {
+export default function Home(): JSX.Element {
   const [newsItems, setNewsItems] = useState<NewsItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const router = useRouter();
 
   useEffect(() => {
-    let interval: NodeJS.Timeout;
+    let interval: ReturnType<typeof setInterval>;
     const handleMagicLinkAndFetch = async () => {
       const supabase = createPagesBrowserClient();
       await supabase.auth.getSession();
-      const { data: { session } } = await supabase.auth.getSession();
 
       const { data, error } = await supabase
         .from('news_items')

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -4,19 +4,21 @@ import { useState } from 'react';
 import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
 import { useRouter } from 'next/navigation';
 
-export default function SignupPage() {
+export default function SignupPage(): JSX.Element {
   const supabase = createClientComponentClient();
   const router = useRouter();
 
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [firstName, setFirstName] = useState('');
-  const [lastName, setLastName] = useState('');
-  const [username, setUsername] = useState('');
-  const [message, setMessage] = useState('');
-  const [showPassword, setShowPassword] = useState(false);
+  const [email, setEmail] = useState<string>('');
+  const [password, setPassword] = useState<string>('');
+  const [firstName, setFirstName] = useState<string>('');
+  const [lastName, setLastName] = useState<string>('');
+  const [username, setUsername] = useState<string>('');
+  const [message, setMessage] = useState<string>('');
+  const [showPassword, setShowPassword] = useState<boolean>(false);
 
-  const handleSignup = async (e: React.FormEvent) => {
+  const handleSignup = async (
+    e: React.FormEvent<HTMLFormElement>
+  ): Promise<void> => {
     e.preventDefault();
 
     const { data, error } = await supabase.auth.signUp({

--- a/src/app/stocks/page.tsx
+++ b/src/app/stocks/page.tsx
@@ -13,14 +13,14 @@ type StockQuote = {
   history: number[];
 };
 
-export default function StocksPage() {
+export default function StocksPage(): JSX.Element {
   const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState<boolean>(true);
   const [stocks, setStocks] = useState<StockQuote[] | null>(null);
-  const [search, setSearch] = useState('');
+  const [search, setSearch] = useState<string>('');
 
   useEffect(() => {
-    const fetchData = async () => {
+    const fetchData = async (): Promise<void> => {
       setLoading(true);
       setError(null);
       try {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,7 +2,7 @@ import { createMiddlewareClient } from '@supabase/auth-helpers-nextjs';
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
-export async function middleware(req: NextRequest) {
+export async function middleware(req: NextRequest): Promise<NextResponse> {
   const res = NextResponse.next();
   const supabase = createMiddlewareClient({ req, res });
 


### PR DESCRIPTION
## Summary
- improve layout with return type
- import shared types in root page and tighten useEffect interval typing
- add TypeScript generics in login and signup forms
- use strong types in admin page
- tighten types in news and stocks pages
- specify return types for API routes and middleware

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c24a7cdf8832db1cfa59a703a2b6d